### PR TITLE
Crystal_Install_Script.py is now implemented

### DIFF
--- a/Common/src/main/java/Utilities/PatcherPython.java
+++ b/Common/src/main/java/Utilities/PatcherPython.java
@@ -54,20 +54,22 @@ public class PatcherPython {
      *
      * @throws IOException thrown if there is an error spawning the script
      */
-    public void patch(boolean devBuild, boolean launchAfter, boolean forceUpdate) throws IOException {
+    public static void patch(boolean devBuild, boolean launchAfter, boolean forceHeart, boolean forceShard) throws IOException {
         String[] params = null;
-        String dev = "", launch = "", force = "";
+        String dev = "", launch = "", forceH = "", forceS = "";
         if (devBuild)
             dev = "-dev";
         if (launchAfter)
             launch = "-launch";
-        if (forceUpdate)
-            force = "-force";
+        if (forceHeart)
+            forceH = "-forceHeart";
+        if (forceShard)
+            forceS = "-forceShard";
 
         if (SystemInfo.getSystem_os() == SystemInfo.SYSTEM_OS.Windows)
-            params = new String[]{"py", "../lib/Crystal_Install_Script.py", dev, launch};
+            params = new String[]{"py", "../lib/Crystal_Install_Script.py", dev, launch, forceH, forceS};
         else if (SystemInfo.getSystem_os() == SystemInfo.SYSTEM_OS.Linux)
-            params = new String[]{"python3", "../lib/Crystal_Install_Script.py", dev, launch};
+            params = new String[]{"python3", "../lib/Crystal_Install_Script.py", dev, launch, forceH, forceS};
 
         Runtime.getRuntime().exec(params);
     }

--- a/Shard/src/main/java/Shard/Manager/ConfigurationManager.java
+++ b/Shard/src/main/java/Shard/Manager/ConfigurationManager.java
@@ -23,6 +23,7 @@ public class ConfigurationManager {
 
     public static final String SHARD_VERSION = "0.1.7";
     public static String SHARD_VERSION_SERVER = "";
+    public static boolean DEV_BUILD;
     // Global variables
     public static String systemName = "CHS Shard", systemLocation = "", commandKey, baseDir = "/CrystalHomeSys/", shardDir = "Shard/",
             logBaseDir = "Logs/", configDir = "shard_config.cfg";

--- a/Shard/src/main/java/Shard/Manager/ConnectionManager.java
+++ b/Shard/src/main/java/Shard/Manager/ConnectionManager.java
@@ -236,10 +236,6 @@ public class ConnectionManager {
         } catch (SendPacketException e) {
             System.err.println("Error sending Heart ID information. Details: " + e.getMessage());
         }
-
-        // Run shard update
-        patcher = new ShardPatcher(client, ShardPatcher.PATCHER_TYPE.runUpdate);
-        patcher.start();
     }
 
     /**

--- a/Shard/src/main/java/Shard/ShardDriver.java
+++ b/Shard/src/main/java/Shard/ShardDriver.java
@@ -18,7 +18,7 @@ import Exceptions.ClientInitializationException;
 public class ShardDriver {
 
     private static Shard_Core shardCore;
-    private static boolean headlessArg = false;
+    private static boolean headlessArg = false, dev = false;
 
     public static void main(String[] args) {
         for (String s : args) {
@@ -26,6 +26,9 @@ public class ShardDriver {
             switch (s) {
                 case "-h":
                     headlessArg = true;
+                    break;
+                case "-dev":
+                    dev = true;
                     break;
             }
         }
@@ -35,7 +38,7 @@ public class ShardDriver {
 
     private static void startShard() {
         try {
-            shardCore = new Shard_Core(headlessArg);
+            shardCore = new Shard_Core(headlessArg, dev);
             shardCore.init();
         } catch (ClientInitializationException ex) {
             System.err.println("Error starting Shard Core. Error: " + ex.getMessage());

--- a/Shard/src/main/java/Shard/Shard_Core.java
+++ b/Shard/src/main/java/Shard/Shard_Core.java
@@ -36,13 +36,14 @@ public class Shard_Core {
     private ConfigurationManager configurationManager;
     private ConnectionManager connectionManager;
 
-    public Shard_Core(boolean headless) throws ClientInitializationException {
+    public Shard_Core(boolean headless, boolean dev) throws ClientInitializationException {
         if (shard_core != null) {
             throw new ClientInitializationException("There can only be one instance of Shard Core!");
         }
         shard_core = this;
         guiManager = new GUIManager(this);
         configurationManager = new ConfigurationManager(this);
+        configurationManager.DEV_BUILD = dev;
         connectionManager = new ConnectionManager(this);
         configurationManager.headless = headless;
     }


### PR DESCRIPTION
Heart and Shard are both install-able from the script.

> The script will search the network for an active Heart server DNSSD service. If found, the script will install a Shard. If not found, it will install a Heart client. This WILL be overridden if any of the force arguments are passed.

This is not currently true. The install script does NOT search the network for DNSSD services. To successfully install the Shard portion of the system, you MUST utilize the `-forceShard` command argument.

The script has the zeroconf dependency. The script will attempt to download the dependency itself, however zeroconf requires C++ 14 or above. If it is not installed, the script will tell you to download the C++ 14 tool box found [here](http://landinghub.visualstudio.com/visual-cpp-build-tools).

-----------------------------------------------

Command line arguments:
-dev : will install the system as dev version
-launch : will launch the installed program after completion
-forceHeart : will force the Heart server to be installed
-forceShard : will force the Shard client to be installed
-help : will list all of the above command

 ----------------------------------------------

An example on running the install script:
`C:\Temp> python Crystal_Install_Script.py -dev -launch`
`C:\Temp> python Crystal_Install_Script.py -dev -forceHeart`

-----------------------------------------------